### PR TITLE
Added additional build args

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -282,6 +282,8 @@
               <buildArgs>
                 <buildArg>-H:IncludeResourceBundles=com.sun.tools.javac.resources.compiler</buildArg>
                 <buildArg>--no-fallback</buildArg>
+                <buildArg>--allow-incomplete-classpath</buildArg>
+                <buildArg>--gc=epsilon</buildArg>
               </buildArgs>
             </configuration>
           </plugin>


### PR DESCRIPTION
--allow-incomplete-classpath allows build for aarch64
--gc=epsilon improves cold start by removing the garbage collector